### PR TITLE
Polling gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,20 @@
     stats = new Stats
       namespace: 'applicationName'
       sdUrl: 'url to statsd'
+      gaugePollPeriodMs: 5 * 1000 # has a default
 
     # counters are sent to statsd
     stats.increment 'counter', 1
     stats.gauge 'gauge', 1
     ...
+
+    # gauges can take event emitters which set the gauge value
+    stats.gauge 'eventedGauge', event: 'foo', emitter: emitter
+    emitter.emit 'foo', 100
+
+    # gauges can take also a poll function which peridically
+    # updates the gauge value
+    stats.gauge 'time', => Date.now()
 
     # key values that are not sent to stats
     stats.key 'started-at', new Date.now()

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "http-proxy": "~>1.9.0",
     "mocha": "~>1.3.2",
     "should": "~>0.6.0",
+    "sinon": "^1.14.1",
     "socket.io-client": "0.9.10"
   },
   "dependencies": {

--- a/src/stats.coffee
+++ b/src/stats.coffee
@@ -34,10 +34,17 @@ class Stats
   gauge: (stat, amount, sampleRate = 1) ->
     if _.isFunction amount
       @_gaugePoller stat, amount, sampleRate
+    else if amount.event && amount.from
+      @_gaugeEvent stat, amount, sampleRate
     else
       @sd.gauge(stat, amount, sampleRate)
       @stats[stat] ||= 0
       @stats[stat] = amount
+
+  _gaugeEvent: (stat, {event, from}, rate) ->
+    @gauge stat, 0, rate
+    from.on event, (level) =>
+      @gauge stat, level, rate
 
   _pollGauges: =>
     _.forEach @_gaugePolls, ({fn, rate}, stat) =>

--- a/src/stats.coffee
+++ b/src/stats.coffee
@@ -3,7 +3,8 @@ url    = require 'url'
 _ = require 'underscore'
 
 class Stats
-  constructor: ({@namespace, sdUrl}) ->
+  constructor: ({@namespace, sdUrl, @gaugePollPeriodMs}) ->
+    @gaugePollPeriodMs ||= 10 * 1000
     sdUrl = url.parse(sdUrl || 'udp://127.0.0.1:8125')
     @namespace ||= (sdUrl.path && sdUrl.path[1..-1]) || 'flowdock'
     @sd = new StatsD
@@ -14,6 +15,8 @@ class Stats
 
     @keys = {}
     @stats = {}
+    @_gaugePolls = {}
+    setInterval @_pollGauges, @gaugePollPeriodMs
 
   increment: (stat, count = 1, sampleRate = 1) ->
     @sd.increment(stat, count, sampleRate)
@@ -29,9 +32,26 @@ class Stats
     @sd.timing stat, time, sampleRate
 
   gauge: (stat, amount, sampleRate = 1) ->
-    @sd.gauge(stat, amount, sampleRate)
-    @stats[stat] ||= 0
-    @stats[stat] = amount
+    if _.isFunction amount
+      @_gaugePoller stat, amount, sampleRate
+    else
+      @sd.gauge(stat, amount, sampleRate)
+      @stats[stat] ||= 0
+      @stats[stat] = amount
+
+  _pollGauges: =>
+    _.forEach @_gaugePolls, ({fn, rate}, stat) =>
+      now = fn()
+      @sd.gauge stat, now, rate
+      @stats[stat] = now
+
+  _gaugePoller: (stat, fn, sampleRate) ->
+    now = fn()
+    @sd.gauge stat, now, sampleRate
+    @stats[stat] = now
+    @_gaugePolls[stat] =
+      fn: fn
+      sampleRate: sampleRate
 
   key: (key, value) ->
     @keys[key] = value

--- a/test/stats.coffee
+++ b/test/stats.coffee
@@ -1,6 +1,7 @@
 Stats = require '../src/stats'
 require 'should'
 sinon = require 'sinon'
+{EventEmitter} = require 'events'
 
 describe 'stats', ->
   beforeEach ->
@@ -15,6 +16,17 @@ describe 'stats', ->
       @clock.restore()
 
   describe 'gauge', ->
+    it 'reacts to events from an event emitter', ->
+      events = new EventEmitter
+      @stats.gauge 'evented',
+        event: 'bar'
+        from: events
+      @stats.stats.evented.should.eql 0
+      events.emit 'foo', 1
+      @stats.stats.evented.should.eql 0
+      events.emit 'bar', 10
+      @stats.stats.evented.should.eql 10
+
     it 'periodically polls an argument function', ->
       value = 1
       @stats.gauge 'foo', -> value


### PR DESCRIPTION
in japiplex and florence we manually set intervals to poll values or set gauge values based on events from libraries. 

This provides a single way to do that.
